### PR TITLE
Wrap CLI helpers in GarminClient class and revise tests

### DIFF
--- a/src/garmin_client.py
+++ b/src/garmin_client.py
@@ -1,18 +1,16 @@
-"""
-Garmin Client Module
+"""Garmin client utilities using the ``garmindb`` CLI."""
 
-Handles Garmin authentication, token refresh, and GET requests with retry logic.
-"""
-
-import requests
-import time
-import subprocess
 import json
-from typing import Dict, Any, Optional
+import subprocess
+import time
+from typing import Any, Dict, Optional
+
 from src.monitoring import log_event
+
 
 def retry(tries: int = 3, delay: int = 5):
     """Retry decorator with exponential backoff."""
+
     def decorator(func):
         def wrapper(*args, **kwargs):
             _tries, _delay = tries, delay
@@ -20,123 +18,149 @@ def retry(tries: int = 3, delay: int = 5):
                 result = func(*args, **kwargs)
                 if result and result.get("returncode", -1) == 0:
                     return result
-                log_event("garmin_client_retry_attempt", {"function": func.__name__, "tries_left": _tries - 1, "delay": _delay})
+                log_event(
+                    "garmin_client_retry_attempt",
+                    {"function": func.__name__, "tries_left": _tries - 1, "delay": _delay},
+                )
                 time.sleep(_delay)
                 _tries -= 1
-                _delay *= 2 # Exponential backoff
-            return func(*args, **kwargs) # Last attempt
+                _delay *= 2
+            return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
 
-# Authentication and token refresh are handled by garmindb_cli.py
-def login():
-    """
-    Placeholder for login. Authentication is handled by garmindb_cli.py.
-    """
+
+# Authentication and token refresh are handled by ``garmindb_cli.py``.
+def login() -> None:
+    """Placeholder for login via ``garmindb_cli.py``."""
+
     log_event("garmin_client_login_placeholder")
     print("Garmin authentication handled by garmindb_cli.py.")
-    pass
+
+
+def refresh_access_token() -> None:
+    """Placeholder for token refresh via ``garmindb_cli.py``."""
+
+    log_event("garmin_client_refresh_placeholder")
+    print("Garmin token refresh handled by garmindb_cli.py.")
+
 
 def _run_garmindb_cli(command_args: list) -> Optional[Dict[str, Any]]:
-    """
-    Runs the garmindb_cli.py script as a subprocess.
-    Args:
-        command_args (list): List of arguments to pass to garmindb_cli.py.
-    Returns:
-        Optional[Dict[str, Any]]: A dictionary containing stdout, stderr, and returncode
-                                   if the subprocess ran, None otherwise (e.g., command not found).
-    """
+    """Run the ``garmindb_cli.py`` script as a subprocess."""
+
     command = ["python", "garmindb_cli.py"] + command_args
     log_event("garmin_client_subprocess_command", {"command": " ".join(command)})
     try:
         result = subprocess.run(command, capture_output=True, text=True, check=False)
-        log_event("garmin_client_subprocess_completed", {
-            "command": " ".join(command),
-            "returncode": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr
-        })
-        return {
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-            "returncode": result.returncode
-        }
+        log_event(
+            "garmin_client_subprocess_completed",
+            {
+                "command": " ".join(command),
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            },
+        )
+        return {"stdout": result.stdout, "stderr": result.stderr, "returncode": result.returncode}
     except FileNotFoundError:
-        log_event("garmin_client_garmindb_cli_not_found", {"message": "garmindb_cli.py command not found. Is it in the PATH or current directory?"})
+        log_event(
+            "garmin_client_garmindb_cli_not_found",
+            {"message": "garmindb_cli.py command not found. Is it in the PATH or current directory?"},
+        )
         return None
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - defensive programming
         log_event("garmin_client_subprocess_exception", {"command": " ".join(command), "error": str(e)})
         return None
 
-# TODO: Implement retry logic
+
 @retry()
-def get_activities(delta_only=False):
-    """
-    Fetches activity data from Garmin using garmindb_cli.py with retry logic.
-    Args:
-        delta_only (bool): If True, fetch only new activities since the last sync.
-    Returns: List of activities (parsed from JSON stdout) or None on failure.
-    """
+def _run_cli(command_args: list) -> Optional[Dict[str, Any]]:
+    return _run_garmindb_cli(command_args)
+
+
+def get_activities(delta_only: bool = False):
+    """Fetch activity data using ``garmindb_cli.py``."""
+
     log_event("garmin_client_get_activities_start", {"delta_only": delta_only})
     command_args = ["fetch", "activities"]
     if delta_only:
         command_args.append("--delta-only")
 
-    result = _run_garmindb_cli(command_args)
-
+    result = _run_cli(command_args)
     if result and result["returncode"] == 0:
         try:
-            # Assuming garmindb_cli.py outputs JSON array of activities to stdout
             activities = json.loads(result["stdout"])
             log_event("garmin_client_get_activities_success", {"count": len(activities)})
             return activities
         except json.JSONDecodeError as e:
-            log_event("garmin_client_get_activities_json_decode_error", {"error": str(e), "stdout": result["stdout"]})
+            log_event(
+                "garmin_client_get_activities_json_decode_error",
+                {"error": str(e), "stdout": result["stdout"]},
+            )
             return None
     else:
         log_event("garmin_client_get_activities_failed", {"result": result})
         return None
 
-# TODO: Implement retry logic
-@retry()
+
 def get_hrv():
-    """
-    Fetches HRV data from Garmin using garmindb_cli.py with retry logic.
-    Returns: List of HRV data (parsed from JSON stdout) or None on failure.
-    """
+    """Fetch HRV data using ``garmindb_cli.py``."""
+
     log_event("garmin_client_get_hrv_start")
     command_args = ["fetch", "hrv"]
-
-    result = _run_garmindb_cli(command_args)
-
+    result = _run_cli(command_args)
     if result and result["returncode"] == 0:
         try:
-            # Assuming garmindb_cli.py outputs JSON array of HRV data to stdout
             hrv_data = json.loads(result["stdout"])
             log_event("garmin_client_get_hrv_success", {"count": len(hrv_data)})
             return hrv_data
         except json.JSONDecodeError as e:
-            log_event("garmin_client_get_hrv_json_decode_error", {"error": str(e), "stdout": result["stdout"]})
+            log_event(
+                "garmin_client_get_hrv_json_decode_error",
+                {"error": str(e), "stdout": result["stdout"]},
+            )
             return None
     else:
         log_event("garmin_client_get_hrv_failed", {"result": result})
         return None
 
-# Retry decorator and token refresh logic implemented.
-# TODO: Implement data update/upload functionality using garmindb_cli.py if needed
-def upload_data(data_type: str, data: Any):
-    """
-    Uploads data to Garmin using garmindb_cli.py if needed.
-    This is a placeholder as garmindb_cli.py might not support uploads.
-    Args:
-        data_type (str): Type of data to upload (e.g., "activities", "hrv").
-        data (Any): The data to upload.
-    Returns: bool: True if upload was attempted (success not guaranteed), False otherwise.
-    """
+
+def upload_data(data_type: str, data: Any) -> bool:
+    """Upload data to Garmin using ``garmindb_cli.py`` if supported."""
+
     log_event("garmin_client_upload_data_stub", {"data_type": data_type})
     print(f"Garmin upload_data function stub for {data_type}.")
     # Example of how you might call garmindb_cli.py if it supported uploads:
     # command_args = ["upload", data_type, json.dumps(data)]
     # result = _run_garmindb_cli(command_args)
     # return result and result["returncode"] == 0
-    return False # Indicate that upload is not implemented via this method
+    return False  # Indicate that upload is not implemented via this method
+
+
+class GarminClient:
+    """Thin wrapper around module-level Garmin client functions."""
+
+    def login(self) -> None:  # pragma: no cover - wrapper delegates to function
+        login()
+
+    def refresh_access_token(self) -> None:  # pragma: no cover - wrapper delegates to function
+        refresh_access_token()
+
+    def get_activities(self, delta_only: bool = False):
+        return get_activities(delta_only=delta_only)
+
+    def get_hrv(self):
+        return get_hrv()
+
+
+__all__ = [
+    "login",
+    "refresh_access_token",
+    "get_activities",
+    "get_hrv",
+    "upload_data",
+    "GarminClient",
+]
+

--- a/tests/test_garmin_client.py
+++ b/tests/test_garmin_client.py
@@ -1,178 +1,84 @@
-"""
-Unit and Integration Tests for the Garmin Client Module.
-"""
+import os
+import sys
+from unittest.mock import patch
 
-import pytest
-from unittest.mock import patch, MagicMock
-
-# Import garmin_client module
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from src import garmin_client
 
-# TODO: Add unit tests for authentication, token refresh, and retry logic
-@patch('src.garmin_client.requests.post')
-def test_garmin_login(mock_post):
-    """
-    Test Garmin login and token refresh.
-    """
-    # Mock successful initial login
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = {"access_token": "new_access_token", "refresh_token": "new_refresh_token"}
 
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.login()
+def _success(payload: str):
+    return {"stdout": payload, "stderr": "", "returncode": 0}
 
-    mock_post.assert_called_once()
-    assert client.access_token == "new_access_token"
-    assert client.refresh_token == "new_refresh_token"
 
-@patch('src.garmin_client.requests.post')
-def test_garmin_login_failure(mock_post):
-    """
-    Test Garmin login failure.
-    """
-    # Mock failed login
-    mock_post.return_value.status_code = 401
+def _failure():
+    return {"stdout": "", "stderr": "", "returncode": 1}
 
-    client = garmin_client.GarminClient("test_email", "test_password")
-    with pytest.raises(Exception): # Assuming login raises an exception on failure
+
+@patch("src.garmin_client._run_garmindb_cli")
+def test_get_activities_success(mock_cli):
+    mock_cli.return_value = _success('[{"id": 1}]')
+    activities = garmin_client.get_activities()
+    mock_cli.assert_called_once_with(["fetch", "activities"])
+    assert activities == [{"id": 1}]
+
+
+@patch("src.garmin_client._run_garmindb_cli")
+def test_get_activities_delta_only(mock_cli):
+    mock_cli.return_value = _success("[]")
+    garmin_client.get_activities(delta_only=True)
+    mock_cli.assert_called_once_with(["fetch", "activities", "--delta-only"])
+
+
+@patch("src.garmin_client.time.sleep", return_value=None)
+def test_get_activities_retry(mock_sleep):
+    with patch(
+        "src.garmin_client._run_garmindb_cli",
+        side_effect=[_failure(), _failure(), _success('[{"id": 2}]')],
+    ) as mock_cli:
+        activities = garmin_client.get_activities()
+        assert mock_cli.call_count == 3
+        assert activities == [{"id": 2}]
+
+
+@patch("src.garmin_client.time.sleep", return_value=None)
+def test_get_hrv_retry(mock_sleep):
+    with patch(
+        "src.garmin_client._run_garmindb_cli",
+        side_effect=[_failure(), _failure(), _success('[{"avg": 50}]')],
+    ) as mock_cli:
+        hrv = garmin_client.get_hrv()
+        assert mock_cli.call_count == 3
+        assert hrv == [{"avg": 50}]
+
+
+@patch("src.garmin_client._run_garmindb_cli", return_value=_failure())
+@patch("src.garmin_client.time.sleep", return_value=None)
+def test_get_activities_failure(mock_sleep, mock_cli):
+    result = garmin_client.get_activities()
+    assert result is None
+    assert mock_cli.call_count == 3
+
+
+@patch("src.garmin_client._run_garmindb_cli", return_value=_failure())
+@patch("src.garmin_client.time.sleep", return_value=None)
+def test_get_hrv_failure(mock_sleep, mock_cli):
+    result = garmin_client.get_hrv()
+    assert result is None
+    assert mock_cli.call_count == 3
+
+
+def test_garmin_client_class_wraps_functions():
+    with patch("src.garmin_client.login") as login_mock, \
+        patch("src.garmin_client.refresh_access_token") as refresh_mock, \
+        patch("src.garmin_client.get_activities", return_value=[]) as activities_mock, \
+        patch("src.garmin_client.get_hrv", return_value={}) as hrv_mock:
+        client = garmin_client.GarminClient()
         client.login()
-
-    mock_post.assert_called_once()
-
-@patch('src.garmin_client.requests.post')
-def test_garmin_refresh_token(mock_post):
-    """
-    Test Garmin token refresh.
-    """
-    # Mock successful token refresh
-    mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = {"access_token": "refreshed_access_token", "refresh_token": "new_refresh_token"}
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.refresh_token = "old_refresh_token" # Set an old refresh token
-    client.refresh_access_token()
-
-    mock_post.assert_called_once()
-    assert client.access_token == "refreshed_access_token"
-    assert client.refresh_token == "new_refresh_token"
-
-@patch('src.garmin_client.requests.post')
-def test_garmin_refresh_token_failure(mock_post):
-    """
-    Test Garmin token refresh failure.
-    """
-    # Mock failed token refresh
-    mock_post.return_value.status_code = 401
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.refresh_token = "old_refresh_token" # Set an old refresh token
-    with pytest.raises(Exception): # Assuming refresh_access_token raises an exception on failure
         client.refresh_access_token()
+        client.get_activities()
+        client.get_hrv()
+        login_mock.assert_called_once()
+        refresh_mock.assert_called_once()
+        activities_mock.assert_called_once_with(delta_only=False)
+        hrv_mock.assert_called_once()
 
-    mock_post.assert_called_once()
-
-@patch('src.garmin_client.requests.get')
-def test_get_activities_integration(mock_get):
-    """
-    Integration test for get_activities using mocks.
-    """
-    # Mock successful API call
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = [{"activityId": 123, "activityName": "Running"}]
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.access_token = "fake_access_token" # Set a fake access token
-    activities = client.get_activities("2023-01-01", "2023-01-07")
-
-    mock_get.assert_called_once()
-    assert len(activities) == 1
-    assert activities[0]["activityName"] == "Running"
-
-@patch('src.garmin_client.requests.get')
-def test_get_hrv_integration(mock_get):
-    """
-    Integration test for get_hrv using mocks.
-    """
-    # Mock successful API call
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {"hrvSummary": {"avgHrv": 50}}
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.access_token = "fake_access_token" # Set a fake access token
-    hrv_data = client.get_hrv("2023-01-01")
-
-    mock_get.assert_called_once()
-    assert hrv_data["hrvSummary"]["avgHrv"] == 50
-
-@patch('src.garmin_client.requests.get')
-def test_get_activities_retry(mock_get):
-    """
-    Test get_activities with retry logic.
-    """
-    # Configure the mock to fail twice then succeed
-    mock_get.side_effect = [
-        MagicMock(status_code=500),
-        MagicMock(status_code=500),
-        MagicMock(status_code=200, json=lambda: [{"activityId": 456, "activityName": "Cycling"}])
-    ]
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.access_token = "fake_access_token" # Set a fake access token
-    # Assuming the client has a retry mechanism built-in
-    activities = client.get_activities("2023-01-01", "2023-01-07")
-
-    # Check that the mock was called three times (2 retries + 1 success)
-    assert mock_get.call_count == 3
-    assert len(activities) == 1
-    assert activities[0]["activityName"] == "Cycling"
-
-@patch('src.garmin_client.requests.get')
-def test_get_hrv_retry(mock_get):
-    """
-    Test get_hrv with retry logic.
-    """
-    # Configure the mock to fail twice then succeed
-    mock_get.side_effect = [
-        MagicMock(status_code=500),
-        MagicMock(status_code=500),
-        MagicMock(status_code=200, json=lambda: {"hrvSummary": {"avgHrv": 60}})
-    ]
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.access_token = "fake_access_token" # Set a fake access token
-    # Assuming the client has a retry mechanism built-in
-    hrv_data = client.get_hrv("2023-01-01")
-
-    # Check that the mock was called three times (2 retries + 1 success)
-    assert mock_get.call_count == 3
-    assert hrv_data["hrvSummary"]["avgHrv"] == 60
-
-@patch('src.garmin_client.requests.get')
-def test_get_activities_failure(mock_get):
-    """
-    Test get_activities failure path.
-    """
-    # Mock failed API call
-    mock_get.return_value.status_code = 400
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.access_token = "fake_access_token" # Set a fake access token
-    with pytest.raises(Exception): # Assuming get_activities raises an exception on failure
-        client.get_activities("2023-01-01", "2023-01-07")
-
-    mock_get.assert_called_once()
-
-@patch('src.garmin_client.requests.get')
-def test_get_hrv_failure(mock_get):
-    """
-    Test get_hrv failure path.
-    """
-    # Mock failed API call
-    mock_get.return_value.status_code = 400
-
-    client = garmin_client.GarminClient("test_email", "test_password")
-    client.access_token = "fake_access_token" # Set a fake access token
-    with pytest.raises(Exception): # Assuming get_hrv raises an exception on failure
-        client.get_hrv("2023-01-01")
-
-    mock_get.assert_called_once()


### PR DESCRIPTION
## Summary
- add `GarminClient` class that delegates to existing module functions
- introduce `_run_cli` helper with retry for CLI calls
- rewrite tests to exercise function-based API and wrapper class

## Testing
- `pytest tests/test_garmin_client.py -q`
- `PYTHONPATH=. pytest -q` *(fails: NameError: name 'Optional' is not defined in src/analytics.py)*

------
https://chatgpt.com/codex/tasks/task_b_6895ad06da448332bb20fd609b1f306a